### PR TITLE
Mod rewrite traffic filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dev-extensions/*
 dev-styles/*
 !dev-extensions/.gitkeep
 !dev-styles/.gitkeep
+web/apache/rewriterules.conf

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dev-extensions/*
 dev-styles/*
 !dev-extensions/.gitkeep
 !dev-styles/.gitkeep
-web/apache/rewriterules.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - ./web/apache/httpd.conf:/etc/apache2/conf-enabled/httpd.conf
       - ./web/apache/usertrack.conf:/etc/apache2/conf-enabled/usertrack.conf
       - ./web/apache/remoteip.conf:/etc/apache2/conf-enabled/remoteip.conf
+      - ./web/apache/rewriterules.conf:/etc/apache2/conf-enabled/rewriterules.conf
     networks:
       backend:
         ipv4_address: 172.40.0.11
@@ -47,6 +48,7 @@ services:
       - ./web/apache/httpd.conf:/etc/apache2/conf-enabled/httpd.conf
       - ./web/apache/usertrack.conf:/etc/apache2/conf-enabled/usertrack.conf
       - ./web/apache/remoteip.conf:/etc/apache2/conf-enabled/remoteip.conf
+      - ./web/apache/rewriterules.conf:/etc/apache2/conf-enabled/rewriterules.conf
     networks:
       backend:
         ipv4_address: 172.40.0.12

--- a/web/apache/rewriterules.conf
+++ b/web/apache/rewriterules.conf
@@ -1,0 +1,17 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    #####
+    ###
+    ### To add additional rules, create a new rule and set the rule flags as [NC,OR]
+    ### Be sure not to alter the last rule, otherwise all traffic will be blocked.
+    ### Apache must be reloaded if changes are made here. You can do so by running the
+    ### following command in the web container: /usr/sbin/apachectl -k graceful
+    ###
+    #####
+
+    RewriteCond %{HTTP_USER_AGENT} claudebot [NC,OR]
+
+    RewriteCond donotchange [NC]
+    RewriteRule .* - [F]
+</IfModule>

--- a/web/vhost_templates/forum.conf.tpl
+++ b/web/vhost_templates/forum.conf.tpl
@@ -19,6 +19,8 @@
 		Require all granted
 		DirectoryIndex index.html index.php
 	</Directory>
+
+	IncludeOptional /etc/apache2/conf-enabled/rewriterules.conf
 	
 	ErrorLog /etc/apache2/logs/error/error.log
 

--- a/web/vhost_templates/wiki.conf.tpl
+++ b/web/vhost_templates/wiki.conf.tpl
@@ -10,6 +10,8 @@
 		Require all granted
 	</Directory>
 
+	IncludeOptional /etc/apache2/conf-enabled/rewriterules.conf
+
 	ErrorLog /etc/apache2/logs/error/error.log
 	
 	# Possible values include: debug, info, notice, warn, error, crit, alert, emerg.

--- a/web/vhost_templates/www.conf.tpl
+++ b/web/vhost_templates/www.conf.tpl
@@ -10,6 +10,8 @@
             Require all granted
     </Directory>
 
+    IncludeOptional /etc/apache2/conf-enabled/rewriterules.conf
+
     ErrorLog /etc/apache2/logs/error/error.log
 
     # Possible values include: debug, info, notice, warn, error, crit, alert, emerg.


### PR DESCRIPTION
This will allow us to set rewrite rules (using Apache mod_rewrite) across www, forum & wiki using a single file to contain all of the rules. This file is located at `forum-deployment/web/apache/rewriterules.conf` Instructions on how to modify the rules & reload Apache are in the comments of the file.